### PR TITLE
Add lint-subql-project job to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -98,3 +98,22 @@ jobs:
       - name: Lint typescript code
         run: |
           yarn lint
+
+  lint-subql-project:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Setup node environment (for linting)
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.16
+
+      - name: Fetch dependencies
+        run: |
+          yarn
+
+      - name: Lint subql project
+        run: |
+          yarn subql validate


### PR DESCRIPTION
Self explanatory. Adds a job to the `lint` workflow to check that `Subql` project is valid.

<img width="638" alt="image" src="https://github.com/okp4/subql-okp4/assets/9574336/3d52bc3c-c294-4f49-8cf3-bf4e29c6abe5">
