### PR TITLE
ci(workflow): add test-docker-compose job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,30 @@ jobs:
       - name: Test project
         run: |
           yarn test
+
+  test-docker-compose:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Setup node environment (for building)
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.16
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Fetch dependencies
+        run: |
+          yarn --frozen-lockfile
+
+      - name: Generate code
+        run: |
+          yarn codegen
+
+      - name: Build project
+        run: |
+          yarn build
+
+      - name: Start Docker Compose
+        uses: isbang/compose-action@v1.5.1
+        timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ yarn prepack
 🚀 Run the project with the default stack:
 
 ```sh
-
-```sh
 yarn start:docker
 ```
 
@@ -98,7 +96,7 @@ subql=> SET schema 'app';
 SET
 subql=> \dt
               List of relations
- Schema |        Name         | Type  | Owner 
+ Schema |        Name         | Type  | Owner
 --------+---------------------+-------+-------
  app    | _metadata           | table | subql
  app    | blocks              | table | subql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       DB_USER: ${DB_SUBQL_USER}
       DB_PASS: ${DB_SUBQL_PASSWORD}
     volumes:
-      - ${PWD}:/app
+      - .:/app
     command:
       - ${SUB_COMMAND}
       - -f=/app
@@ -59,7 +59,7 @@ services:
     environment:
       DB_HOST: postgres
       DB_PORT: ${DB_POSTGRES_PORT}
-      DB_DATABASE: ${DB_SUBQL_NAME}
+      DB_DATABASE: ${DB_POSTGRES_NAME}
       DB_USER: ${DB_SUBQL_USER}
       DB_PASS: ${DB_SUBQL_PASSWORD}
     command:


### PR DESCRIPTION
Addresses issue #76 by introducing a new GitHub Action Job designed to test the Docker Compose configuration in the Github CI pipeline. The solution relies on [isbang/compose-action](https://github.com/isbang/compose-action) to handle the entire lifecycle of Docker.