### PR TITLE
Feat/objectarium instance

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,7 @@ module.exports = {
     },
     plugins: ["@typescript-eslint"],
     rules: {
-        indent: ["error", 4],
+        indent: ["error", 4, { SwitchCase: 1 }],
         "linebreak-style": ["error", "unix"],
         quotes: ["error", "double"],
         semi: ["error", "always"],

--- a/project.yaml
+++ b/project.yaml
@@ -26,9 +26,10 @@ network:
       file: ./proto/cosmwasm/wasm/v1/tx.proto
       messages:
         - MsgExecuteContract
+        - MsgInstantiateContract
 dataSources:
   - kind: cosmos/Runtime
-    startBlock: 3507305
+    startBlock: 2720090
     mapping:
       file: ./dist/index.js
       handlers:
@@ -56,3 +57,10 @@ dataSources:
           filter:
             type: /cosmwasm.wasm.v1.MsgExecuteContract
             contractCall: unpin_object
+        - handler: handleInitObjectarium
+          kind: cosmos/MessageHandler
+          filter:
+            type: /cosmwasm.wasm.v1.MsgInstantiateContract
+            contractCall: instantiate
+            attributes:
+              code_id: "4"

--- a/project.yaml
+++ b/project.yaml
@@ -62,5 +62,3 @@ dataSources:
           filter:
             type: /cosmwasm.wasm.v1.MsgInstantiateContract
             contractCall: instantiate
-            attributes:
-              code_id: "4"

--- a/schema.graphql
+++ b/schema.graphql
@@ -133,6 +133,10 @@ type Message @entity {
     """
     block: Block!
     """
+    Objectarium that message relates to (for a message which concerns an objectarium smart contract).
+    """
+    objectarium: Objectarium
+    """
     Object that message relates to (for a message which concerns an object).
     """
     objectariumObject: ObjectariumObject
@@ -231,4 +235,8 @@ type Objectarium @entity {
     List of objects contained within the Objectarium instance.
     """
     objectariumObjects: [ObjectariumObject] @derivedFrom(field: "objectarium")
+    """
+    List of messages that concern the entity.
+    """
+    messages: [Message]! @derivedFrom(field: "objectarium")
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -166,6 +166,43 @@ type ObjectariumObject @entity {
 }
 
 """
+BucketConfig is the type of the configuration of a bucket.
+"""
+type BucketConfig @jsonField {
+    """
+    The algorithm used to hash the content of the objects to generate the id of the objects.
+    """
+    hashAlgorithm: String
+    """
+    The acceptable compression algorithms for the objects in the bucket.
+    """
+    acceptedCompressionAlgorithms: [String!]
+}
+
+"""
+BucketLimits is the type of the limits of a Objectarium bucket.
+The limits are optional and if not set, there is no limit.
+"""
+type BucketLimits @jsonField {
+    """
+    The maximum total size of the objects in the bucket.
+    """
+    maxTotalSize: BigInt
+    """
+    The maximum number of objects in the bucket.
+    """
+    maxObjects: BigInt
+    """
+    The maximum size of the objects in the bucket.
+    """
+    maxObjectSize: BigInt
+    """
+    The maximum number of pins in the bucket for an object.
+    """
+    maxObjectPins: BigInt
+}
+
+"""
 Objectarium smart contract instance (aka bucket).
 """
 type Objectarium @entity {
@@ -182,6 +219,14 @@ type Objectarium @entity {
     The name of the bucket.
     """
     name: String!
+    """
+    The configuration of the bucket.
+    """
+    config: BucketConfig
+    """
+    The limits of the bucket.
+    """
+    limits: BucketLimits
     """
     List of objects contained within the Objectarium instance.
     """

--- a/schema.graphql
+++ b/schema.graphql
@@ -220,6 +220,10 @@ type Objectarium @entity {
     """
     owner: String!
     """
+    Label of the bucket.
+    """
+    label: String!
+    """
     The name of the bucket.
     """
     name: String!

--- a/schema.graphql
+++ b/schema.graphql
@@ -152,9 +152,9 @@ type ObjectariumObject @entity {
     """
     sender: String! @index
     """
-    Address of the smart contract instance (aka bucket) where the object is stored.
+    The smart contract instance (aka bucket) where the object is stored.
     """
-    contract: String! @index
+    objectarium: Objectarium!
     """
     Addresses that have pinned the object.
     """
@@ -163,4 +163,27 @@ type ObjectariumObject @entity {
     List of messages that concern the object.
     """
     messages: [Message]! @derivedFrom(field: "objectariumObject")
+}
+
+"""
+Objectarium smart contract instance (aka bucket).
+"""
+type Objectarium @entity {
+    """
+    Identifier of the smart contract instance.
+    It is the address of the smart contract instance.
+    """
+    id: ID!
+    """
+    The owner of the bucket.
+    """
+    owner: String!
+    """
+    The name of the bucket.
+    """
+    name: String!
+    """
+    List of objects contained within the Objectarium instance.
+    """
+    objectariumObjects: [ObjectariumObject] @derivedFrom(field: "objectarium")
 }

--- a/src/mappings/helper.ts
+++ b/src/mappings/helper.ts
@@ -1,4 +1,41 @@
 import { CosmosEvent, CosmosMessage } from "@subql/types-cosmos";
+import { Message } from "../types";
 
 export const messageId = (msg: CosmosMessage | CosmosEvent): string =>
     `${msg.tx.hash}-${msg.idx}`;
+
+export const referenceEntityInMessage = async (
+    msg: CosmosMessage,
+    entity: {
+        id: string;
+        messageField: keyof Pick<
+            Message,
+            | "objectariumObjectId"
+            | "objectariumId"
+            | "blockId"
+            | "transactionId"
+        >;
+    },
+): Promise<void> => {
+    const message = await Message.get(messageId(msg));
+    if (!message) {
+        return;
+    }
+
+    switch (entity.messageField) {
+        case "objectariumObjectId":
+            message.objectariumObjectId = entity.id;
+            break;
+        case "objectariumId":
+            message.objectariumId = entity.id;
+            break;
+        case "blockId":
+            message.blockId = entity.id;
+            break;
+        case "transactionId":
+            message.transactionId = entity.id;
+            break;
+    }
+
+    await message.save();
+};

--- a/src/mappings/helper.ts
+++ b/src/mappings/helper.ts
@@ -1,8 +1,24 @@
-import { CosmosEvent, CosmosMessage } from "@subql/types-cosmos";
+import type { CosmosEvent, CosmosMessage } from "@subql/types-cosmos";
 import { Message } from "../types";
+import type {
+    Event,
+    Attribute,
+} from "@cosmjs/tendermint-rpc/build/tendermint37";
 
 export const messageId = (msg: CosmosMessage | CosmosEvent): string =>
     `${msg.tx.hash}-${msg.idx}`;
+
+export const findEvent = (
+    events: Readonly<Event[]>,
+    event: string,
+): Event | undefined => events.find(({ type }) => type === event);
+
+export const findEventAttribute = (
+    events: Readonly<Event[]>,
+    event: string,
+    attribute: string,
+): Attribute | undefined =>
+    findEvent(events, event)?.attributes.find(({ key }) => key === attribute);
 
 export const referenceEntityInMessage = async (
     msg: CosmosMessage,

--- a/src/mappings/objectariumHandlers.ts
+++ b/src/mappings/objectariumHandlers.ts
@@ -9,7 +9,7 @@ import {
     BucketConfig,
     BucketLimits,
 } from "../types";
-import { referenceEntityInMessage } from "./helper";
+import { findEventAttribute, referenceEntityInMessage } from "./helper";
 import type { Event } from "@cosmjs/tendermint-rpc/build/tendermint37";
 
 type StoreObject = {
@@ -130,19 +130,22 @@ export const handleUnpinObject = async (
 export const handleInitObjectarium = async (
     msg: CosmosMessage<ObjectariumMsg<Instantiate>>,
 ): Promise<void> => {
-    const contractAddress = msg.tx.tx.events
-        .find(({ type }) => type === "instantiate")
-        ?.attributes.find((attribute) => attribute.key === "_contract_address")
-        ?.value;
+    const contractAddress = findEventAttribute(
+        msg.tx.tx.events,
+        "instantiate",
+        "_contract_address",
+    )?.value;
 
     // TODO: filter the calling of this handler through the manifest.
     // Justification: There seems to be a bug with the filtering of events
     // that make it impossible to filter on the contract code id. The
     // following codeId variable allows to filter the handling of the
     // message before treating the msg as a objectarium instantiate msg.
-    const codeId = msg.tx.tx.events
-        .find(({ type }) => type === "instantiate")
-        ?.attributes.find((attribute) => attribute.key === "code_id")?.value;
+    const codeId = findEventAttribute(
+        msg.tx.tx.events,
+        "instantiate",
+        "code_id",
+    )?.value;
 
     if (!contractAddress || codeId !== "4") {
         return;
@@ -193,7 +196,4 @@ export const retrieveObjectariumObject = async (
 
 export const objectariumObjectId = (
     events: Readonly<Event[]>,
-): string | undefined =>
-    events
-        .find((event) => event.type === "wasm")
-        ?.attributes.find((attribute) => attribute.key === "id")?.value;
+): string | undefined => findEventAttribute(events, "wasm", "id")?.value;

--- a/src/mappings/objectariumHandlers.ts
+++ b/src/mappings/objectariumHandlers.ts
@@ -150,6 +150,7 @@ export const handleInitObjectarium = async (
 
     const {
         sender,
+        label,
         msg: { bucket, limits: bucketLimits, config: bucketConfig },
     } = msg.msg.decodedMsg;
     const limits: BucketLimits = {
@@ -167,6 +168,7 @@ export const handleInitObjectarium = async (
     await Objectarium.create({
         id: contractAddress,
         owner: sender,
+        label,
         name: bucket,
         config,
         limits,

--- a/src/mappings/objectariumHandlers.ts
+++ b/src/mappings/objectariumHandlers.ts
@@ -102,7 +102,16 @@ export const handleInitObjectarium = async (
         ?.attributes.find((attribute) => attribute.key === "_contract_address")
         ?.value;
 
-    if (!contractAddress) {
+    // TODO: filter the calling of this handler through the manifest.
+    // Justification: There seems to be a bug with the filtering of events
+    // that make it impossible to filter on the contract code id. The
+    // following codeId variable allows to filter the handling of the
+    // message before treating the msg as a objectarium instantiate msg.
+    const codeId = msg.tx.tx.events
+        .find(({ type }) => type === "instantiate")
+        ?.attributes.find((attribute) => attribute.key === "code_id")?.value;
+
+    if (!contractAddress || codeId !== "4") {
         return;
     }
 

--- a/src/mappings/objectariumHandlers.ts
+++ b/src/mappings/objectariumHandlers.ts
@@ -4,13 +4,12 @@ import type {
     MsgInstantiateContract,
 } from "cosmjs-types/cosmwasm/wasm/v1/tx";
 import {
-    Message,
     ObjectariumObject,
     Objectarium,
     BucketConfig,
     BucketLimits,
 } from "../types";
-import { messageId } from "./helper";
+import { referenceEntityInMessage } from "./helper";
 import type { Event } from "@cosmjs/tendermint-rpc/build/tendermint37";
 
 type StoreObject = {
@@ -64,7 +63,10 @@ export const handleStoreObject = async (
         pins: isPinned ? [sender] : [],
     }).save();
 
-    await referenceObjectInMessage(msg, objectId);
+    await referenceEntityInMessage(msg, {
+        messageField: "objectariumObjectId",
+        id: objectId,
+    });
 };
 
 export const handleForgetObject = async (
@@ -76,7 +78,10 @@ export const handleForgetObject = async (
     }
 
     await ObjectariumObject.remove(objectId);
-    await referenceObjectInMessage(msg, objectId);
+    await referenceEntityInMessage(msg, {
+        messageField: "objectariumObjectId",
+        id: objectId,
+    });
 };
 
 export const handlePinObject = async (
@@ -94,7 +99,10 @@ export const handlePinObject = async (
         await object.save();
     }
 
-    await referenceObjectInMessage(msg, object.id);
+    await referenceEntityInMessage(msg, {
+        messageField: "objectariumObjectId",
+        id: object.id,
+    });
 };
 
 export const handleUnpinObject = async (
@@ -113,7 +121,10 @@ export const handleUnpinObject = async (
         await object.save();
     }
 
-    await referenceObjectInMessage(msg, object.id);
+    await referenceEntityInMessage(msg, {
+        messageField: "objectariumObjectId",
+        id: object.id,
+    });
 };
 
 export const handleInitObjectarium = async (
@@ -160,19 +171,11 @@ export const handleInitObjectarium = async (
         config,
         limits,
     }).save();
-};
 
-export const referenceObjectInMessage = async (
-    msg: CosmosMessage,
-    objectId: string,
-): Promise<void> => {
-    const message = await Message.get(messageId(msg));
-    if (!message) {
-        return;
-    }
-
-    message.objectariumObjectId = objectId;
-    await message.save();
+    await referenceEntityInMessage(msg, {
+        messageField: "objectariumId",
+        id: contractAddress,
+    });
 };
 
 export const retrieveObjectariumObject = async (


### PR DESCRIPTION
This PR finishes the following issue by implementing a objectarium handler for indexing the initialization of objectarium smart contracts:
- #7 

As of date there seems to be a problem filtering the code id through the manifest so the contract filtering is implemented in the handler.

<details>
<summary>objectaria query including config and limits</summary>

```gql
{
  "data": {
    "query": {
      "objectaria": {
        "id": "okp41jg5y3m2u9ac50g5jsd7mksh3y9nvp3pyuf5fj8entsk9tv2tq4gsv9r25d",
        "owner": "okp41zn4x0geu5eemk7ul05ld7n9e4kzs7cxx4al3fs",
        "config": {
          "hashAlgorithm": "sha224",
          "acceptedCompressionAlgorithms": [
            "snappy"
          ]
        },
        "limits": {
          "maxObjects": "20",
          "maxTotalSize": "1000",
          "maxObjectPins": "1",
          "maxObjectSize": "50"
        },
        "objectariumObjects": {
          "nodes": []
        },
        "messages": {
          "nodes": [
            {
              "block": {
                "height": "4004814"
              }
            }
          ]
        }
      }
    }
  }
}
```
</details>