### PR TITLE
build: specify commits that trigger a release

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,6 +4,26 @@ branches:
 plugins:
   - - "@semantic-release/commit-analyzer"
     - preset: conventionalcommits
+      releaseRules:
+        - type: build
+          scope: deps
+          release: patch
+        - type: build
+          scope: deps-dev
+          release: patch
+        - type: refactor
+          release: patch
+        - type: style
+          release: patch
+        - type: ci
+          release: patch
+        - type: chore
+          release: patch
+        - type: docs
+          scope: schema
+          release: minor
+        - type: docs
+          release: patch
   - - "@semantic-release/release-notes-generator"
     - preset: conventionalcommits
   - - "@semantic-release/changelog"


### PR DESCRIPTION
Specify the commits that should trigger a release (cf. [semantic-release/commit-analyzer](https://github.com/semantic-release/commit-analyzer/)), especially those affecting the project's behavior, for instance `build(deps)`, `build(deps-dev)` and `docs(schema)` categories.

---
@amimart Need this to enable a new release of the indexer based on the latest subql dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the release rules for different commit types to define patch and minor releases more accurately.
	- Added a specific release rule for "docs" type with "schema" scope, which will now trigger a minor release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->