### PR TITLE
build(project): fix GitHub release assets

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -48,17 +48,20 @@ plugins:
   - - "@semantic-release/exec"
     - prepareCmd: |
         yarn prepack
+  - - "@semantic-release/exec"
+    - prepareCmd: |
+        tar -cvzf dist/subql-okp4-${nextRelease.version}.tar.gz \
+          dist/index.js \
+          package.json \
+          project.yaml \
+          schema.graphql \
+          README.md \
+          CHANGELOG.md \
+          LICENSE
   - - "@semantic-release/github"
     - assets:
-        - label: Packaged JS Code
-          path:
-            - dist/index.js
-            - package.json
-            - project.yaml
-            - schema.graphql
-            - README.md
-            - CHANGELOG.md
-            - LICENSE
+        - label: Tarball (tar.gz)
+          path: dist/subql-okp4-*.tar.gz
         - label: Schema
           path: schema.graphql
   - - "@semantic-release/git"


### PR DESCRIPTION
Correct the misconfigured assets generated during the release process (see screenshot).

<img width="919" alt="image" src="https://github.com/okp4/subql-okp4/assets/9574336/fb9034a6-0365-4c6b-9ee3-c2be219a2164">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The release process now automatically creates a versioned tarball of the application for distribution.

- **Documentation**
  - Updated release documentation to reflect the new tarball creation and upload steps.

- **Chores**
  - Configured release automation to enhance the build and deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->